### PR TITLE
Performance fixes

### DIFF
--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -134,7 +134,7 @@
                         fill="none"
                         in:draw={{ duration: 250, easing: quadInOut }}
                     />
-                    {#each line.x as x, i}
+                    <!--{#each line.x as x, i}
                         <circle
                             in:fade={{ duration: 100 }}
                             use:tooltip={{
@@ -149,7 +149,7 @@
                             cy={line.y[i]}
                             r="3"
                         />
-                    {/each}
+                    {/each}-->
                 </g>
             {/each}
         </g></svg

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -61,7 +61,7 @@
     }
 
     function update_data(selected_variable) {
-        filtered_data = $csv_data?.data?.filter((d) => d.name === selected_variable);
+        filtered_data = $csv_data?.data[selected_variable];
 
         let xvals = filtered_data?.map((d) => d.date);
         let yvals = filtered_data?.map((d) => d.value);
@@ -142,7 +142,7 @@
                     />
                     {#each line.x as x, i}
                         <circle
-                            in:fade={{duration:100}}
+                            in:fade={{ duration: 100 }}
                             use:tooltip={{
                                 content: `${line.stat_code}: ${Math.floor(
                                     scale_y.invert(line.y[i])

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -61,20 +61,11 @@
     }
 
     function update_data(selected_variable) {
-        filtered_data = $csv_data?.data[selected_variable];
-
-        let xvals = filtered_data?.map((d) => d.date);
-        let yvals = filtered_data?.map((d) => d.value);
-
-        if (xvals && yvals) {
-            min_x = Math.min(...xvals);
-            min_y = Math.min(...yvals);
-            max_x = Math.max(...xvals);
-            max_y = Math.max(...yvals);
-        }
-
-        scale_x.domain([min_x, max_x]);
-        scale_y.domain([0, max_y]);
+        filtered_data = $csv_data?.data[selected_variable]?.data;
+        let extremes = $csv_data?.data[selected_variable]?.extremes;
+        
+        scale_x.domain([extremes?.min_x, extremes?.max_x]);
+        scale_y.domain([0, extremes?.max_y]);
         handle_resize(width, height);
     }
 

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -22,7 +22,6 @@
     let scale_y = scaleLinear();
     let date_x_pos = tweened(void 0, { duration: 150, easing: cubicOut });
 
-    let min_x, min_y, max_x, max_y;
     let filtered_data;
     let plot_data;
 
@@ -61,12 +60,16 @@
     }
 
     function update_data(selected_variable) {
-        filtered_data = $csv_data?.data[selected_variable]?.data;
-        let extremes = $csv_data?.data[selected_variable]?.extremes;
-        
-        scale_x.domain([extremes?.min_x, extremes?.max_x]);
-        scale_y.domain([0, extremes?.max_y]);
-        handle_resize(width, height);
+        if (selected_variable) {
+            filtered_data = Object.values($csv_data.data[selected_variable].data)
+                .map((e) => e.data)
+                .flat();
+            let extremes = $csv_data?.data[selected_variable]?.extremes;
+
+            scale_x.domain([extremes?.min_x, extremes?.max_x]);
+            scale_y.domain([0, extremes?.max_y]);
+            handle_resize(width, height);
+        }
     }
 
     function polyline_string(x, y) {

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -7,6 +7,8 @@
     import { tweened } from "svelte/motion";
     import { quadInOut, cubicOut } from "svelte/easing";
 
+    const CIRCLE_RADIUS = 2;
+
     let width = 0;
     let height = 0;
 
@@ -82,11 +84,11 @@
     function polyline_string(x, y) {
         let res = "";
 
-        res += `M${x[0]},${y[0]}${circle_path(2)}`;
+        res += `M${x[0]},${y[0]}${circle_path(CIRCLE_RADIUS)}`;
 
         if (x.length > 1) {
             for (let i = 1; i < x.length; i++) {
-                res += `L${x[i]},${y[i]}${circle_path(2)}`;
+                res += `L${x[i]},${y[i]}${circle_path(CIRCLE_RADIUS)}`;
             }
         }
 
@@ -131,24 +133,22 @@
         <!-- Data points -->
         <g>
             {#each plot_data as line (line.stat_code + $selected_variable)}
-                <g
+                >
+                <path
+                    d={polyline_string(line.x, line.y)}
+                    in:draw={{ duration: 250, easing: quadInOut }}
                     style={`
-                    opacity: ${
-                        (!$stat_hovered && line.dates.has($selected_date)) ||
-                        line.stat_code === $stat_hovered
-                            ? 1
-                            : 0.2
-                    };`}
+                            opacity: ${
+                                (!$stat_hovered &&
+                                    line.dates.has($selected_date)) ||
+                                line.stat_code === $stat_hovered
+                                    ? 1
+                                    : 0.2
+                            };`}
                     class="transition-opacity"
                     stroke="black"
-                >
-                    <path
-                        d={polyline_string(line.x, line.y)}
-                        fill="black"
-                        stroke="black"
-                        in:draw={{ duration: 250, easing: quadInOut }}
-                    />
-                </g>
+                    fill="black"
+                />
             {/each}
         </g></svg
     >

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -3,8 +3,7 @@
     import { scaleTime, scaleLinear } from "d3-scale";
     import { stat_hovered } from "../store.js";
     import Tick from "./Tick.svelte";
-    import { tooltip } from "../tooltip.js";
-    import { draw, fade } from "svelte/transition";
+    import { draw } from "svelte/transition";
     import { tweened } from "svelte/motion";
     import { quadInOut, cubicOut } from "svelte/easing";
 
@@ -61,7 +60,9 @@
 
     function update_data(selected_variable) {
         if (selected_variable) {
-            filtered_data = Object.values($csv_data.data[selected_variable].data)
+            filtered_data = Object.values(
+                $csv_data.data[selected_variable].data
+            )
                 .map((e) => e.data)
                 .flat();
             let extremes = $csv_data?.data[selected_variable]?.extremes;
@@ -72,12 +73,24 @@
         }
     }
 
+    function circle_path(r) {
+        return `m${-r},0a${r},${r} 0 1,0 ${r * 2},0a${r},${r} 0 1,0 ${
+            -r * 2
+        },0m${r},0`;
+    }
+
     function polyline_string(x, y) {
-        let points = [];
-        for (let i in x) {
-            points.push(`${x[i]},${y[i]}`);
+        let res = "";
+
+        res += `M${x[0]},${y[0]}${circle_path(2)}`;
+
+        if (x.length > 1) {
+            for (let i = 1; i < x.length; i++) {
+                res += `L${x[i]},${y[i]}${circle_path(2)}`;
+            }
         }
-        return points.join(" ");
+
+        return res;
     }
 
     $: handle_resize(width, height);
@@ -129,27 +142,12 @@
                     class="transition-opacity"
                     stroke="black"
                 >
-                    <polyline
-                        points={polyline_string(line.x, line.y)}
-                        fill="none"
+                    <path
+                        d={polyline_string(line.x, line.y)}
+                        fill="black"
+                        stroke="black"
                         in:draw={{ duration: 250, easing: quadInOut }}
                     />
-                    <!--{#each line.x as x, i}
-                        <circle
-                            in:fade={{ duration: 100 }}
-                            use:tooltip={{
-                                content: `${line.stat_code}: ${Math.floor(
-                                    scale_y.invert(line.y[i])
-                                )}`,
-                            }}
-                            on:mouseleave={() => ($stat_hovered = void 0)}
-                            on:mouseenter={() =>
-                                ($stat_hovered = line.stat_code)}
-                            cx={x}
-                            cy={line.y[i]}
-                            r="3"
-                        />
-                    {/each}-->
                 </g>
             {/each}
         </g></svg

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -61,7 +61,7 @@
     }
 
     function update_data(selected_variable) {
-        filtered_data = $csv_data?.filter((d) => d.name === selected_variable);
+        filtered_data = $csv_data?.data?.filter((d) => d.name === selected_variable);
 
         let xvals = filtered_data?.map((d) => d.date);
         let yvals = filtered_data?.map((d) => d.value);

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -82,9 +82,7 @@
     }
 
     function polyline_string(x, y) {
-        let res = "";
-
-        res += `M${x[0]},${y[0]}${circle_path(CIRCLE_RADIUS)}`;
+        let res = `M${x[0]},${y[0]}${circle_path(CIRCLE_RADIUS)}`;
 
         if (x.length > 1) {
             for (let i = 1; i < x.length; i++) {
@@ -133,7 +131,6 @@
         <!-- Data points -->
         <g>
             {#each plot_data as line (line.stat_code + $selected_variable)}
-                >
                 <path
                     d={polyline_string(line.x, line.y)}
                     in:draw={{ duration: 250, easing: quadInOut }}

--- a/src/lib/components/NetherlandsMap.svelte
+++ b/src/lib/components/NetherlandsMap.svelte
@@ -68,7 +68,7 @@
 
     function calculate_colors(selected_variable, selected_date) {
         if (selected_variable && selected_date) {
-            const selected_data = $csv_data.data[selected_variable].filter(
+            const selected_data = $csv_data.data[selected_variable].data.filter(
                 (d) => d.date == selected_date
             );
             n_datapoints = selected_data?.length;

--- a/src/lib/components/NetherlandsMap.svelte
+++ b/src/lib/components/NetherlandsMap.svelte
@@ -68,8 +68,8 @@
 
     function calculate_colors(selected_variable, selected_date) {
         if (selected_variable && selected_date) {
-            const selected_data = $csv_data.data.filter(
-                (d) => d.name == selected_variable && d.date == selected_date
+            const selected_data = $csv_data.data[selected_variable].filter(
+                (d) => d.date == selected_date
             );
             n_datapoints = selected_data?.length;
 

--- a/src/lib/components/NetherlandsMap.svelte
+++ b/src/lib/components/NetherlandsMap.svelte
@@ -68,7 +68,7 @@
 
     function calculate_colors(selected_variable, selected_date) {
         if (selected_variable && selected_date) {
-            const selected_data = $csv_data.filter(
+            const selected_data = $csv_data.data.filter(
                 (d) => d.name == selected_variable && d.date == selected_date
             );
             n_datapoints = selected_data?.length;

--- a/src/lib/components/NetherlandsMap.svelte
+++ b/src/lib/components/NetherlandsMap.svelte
@@ -68,15 +68,16 @@
 
     function calculate_colors(selected_variable, selected_date) {
         if (selected_variable && selected_date) {
-            const selected_data = $csv_data.data[selected_variable].data.filter(
-                (d) => d.date == selected_date
-            );
+            const selected_data =
+                $csv_data.data[selected_variable]?.data[selected_date]?.data;
             n_datapoints = selected_data?.length;
 
             const new_colors = {};
             const new_values = {};
 
-            max = Math.max(...selected_data.map((d) => d.value));
+            max =
+                $csv_data.data[selected_variable].data[selected_date]?.extremes
+                    .max_y;
             scale.domain([0, max]);
 
             for (const i in selected_data) {

--- a/src/lib/components/selectors/VariableSelector.svelte
+++ b/src/lib/components/selectors/VariableSelector.svelte
@@ -1,43 +1,28 @@
 <script>
     import { csv_data, selected_variable, selected_date } from "../../store.js";
 
-    let variables = [];
-
-    let selected_date_idx;
-    let dates;
-
-    function update_ranges($csv_data) {
-        if ($csv_data) {
-            const unique_variables = new Set();
-            dates = new Set();
-
-            for (const i in $csv_data) {
-                unique_variables.add($csv_data[i].name);
-                dates.add($csv_data[i].date);
-            }
-
-            dates = [...dates];
-            dates.sort();
-
-            variables = [...unique_variables];
-            selected_date_idx = dates.length - 1;
-            $selected_date = dates[selected_date_idx];
-            $selected_variable = variables[0];
-        }
-    }
-
     function format_date(date_epoch) {
         let date = new Date(date_epoch);
         return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
     }
 
-    // If csv data changes, find unique variables
-    // Also find date range for slider
-    $: update_ranges($csv_data);
-    $: $selected_date = isFinite(selected_date_idx) ? dates[selected_date_idx] : void 0;
+    const init_selection = (data) => {
+        selected_date_idx = data.ranges.dates.length - 1;
+        $selected_variable = data.ranges.variables[0];
+    };
+
+    let selected_date_idx;
+
+    $: if ($csv_data) {
+        init_selection($csv_data);
+    }
+
+    $: if (isFinite(selected_date_idx)) {
+        $selected_date = $csv_data.ranges.dates[selected_date_idx];
+    }
 </script>
 
-{#if $selected_variable}
+{#if $csv_data}
     <div class="mb-4">
         <label for="variable_select">Selecteer variabele:</label>
         <select
@@ -45,7 +30,7 @@
             name="variable_select"
             id="variable_select"
         >
-            {#each variables as variable}
+            {#each $csv_data.ranges.variables as variable}
                 <option value={variable}>{variable}</option>
             {/each}
         </select>
@@ -56,7 +41,7 @@
         id="date_select"
         type="range"
         min={0}
-        max={dates.length - 1}
+        max={$csv_data.ranges.dates.length - 1}
         step={1}
         bind:value={selected_date_idx}
     />

--- a/src/lib/loader.worker.js
+++ b/src/lib/loader.worker.js
@@ -1,6 +1,6 @@
 import Papa from "papaparse";
 
-const parse_csv = (file, expected_fields) => {
+function parse_csv(file, expected_fields) {
     return new Promise((resolve, reject) => {
         Papa.parse(file, {
             header: true,
@@ -41,13 +41,34 @@ const parse_csv = (file, expected_fields) => {
     });
 };
 
+function calculate_ranges(data) {
+    const unique_variables = new Set();
+    const dates = new Set();
+
+    for (const i in data) {
+        unique_variables.add(data[i].name);
+        dates.add(data[i].date);
+    }
+
+    return {
+        variables: [...unique_variables],
+        dates: [...dates],
+    }
+}
+
 onmessage = async (msg) => {
     // Load csv file
     if (msg.data.file) {
         try {
             console.log("Reading csv file in worker...");
             let data = await parse_csv(msg.data.file, msg.data.expected_fields);
-            postMessage({ result: data });
+            let ranges = calculate_ranges(data);
+            postMessage({
+                result: {
+                    data,
+                    ranges
+                }
+            });
         } catch (e) {
             postMessage({ error: e });
         }

--- a/src/lib/loader.worker.js
+++ b/src/lib/loader.worker.js
@@ -90,17 +90,32 @@ function group_data(data) {
     let grouped = {}
 
     for (let row of data) {
+        // Variable level
         if (!grouped[row.name]) {
             grouped[row.name] = {
+                data: {}
+            };
+        }
+
+        // Date level
+        if (!grouped[row.name].data[row.date]) {
+            grouped[row.name].data[row.date] = {
                 data: []
             };
         }
-        grouped[row.name].data.push(row);
+
+        grouped[row.name].data[row.date].data.push(row);
     }
 
-    for (let group of Object.keys(grouped)) {
-        grouped[group].extremes = get_extremes(grouped[group].data);
+    for (let variable of Object.keys(grouped)) {
+        let rows = Object.values(grouped[variable].data).map(e => e.data).flat();
+        grouped[variable].extremes = get_extremes(rows);
+        for (let date of Object.keys(grouped[variable].data)) {
+            grouped[variable].data[date].extremes = get_extremes(grouped[variable].data[date].data);
+        }
     }
+
+    console.log(grouped);
 
     return grouped;
 }

--- a/src/lib/loader.worker.js
+++ b/src/lib/loader.worker.js
@@ -56,16 +56,31 @@ function calculate_ranges(data) {
     }
 }
 
+function group_data(data) {
+    let res = {}
+
+    for (let i in data) {
+        if (!res[data[i].name]) {
+            res[data[i].name] = [];
+        }
+        res[data[i].name].push(data[i]);
+    }
+
+    return res;
+}
+
 onmessage = async (msg) => {
     // Load csv file
     if (msg.data.file) {
         try {
             console.log("Reading csv file in worker...");
-            let data = await parse_csv(msg.data.file, msg.data.expected_fields);
-            let ranges = calculate_ranges(data);
+            let raw_data = await parse_csv(msg.data.file, msg.data.expected_fields);
+            let ranges = calculate_ranges(raw_data);
+            let data = group_data(raw_data);
+
             postMessage({
                 result: {
-                    data,
+                    data: data,
                     ranges
                 }
             });

--- a/src/lib/loader.worker.js
+++ b/src/lib/loader.worker.js
@@ -1,0 +1,55 @@
+import Papa from "papaparse";
+
+const parse_csv = (file, expected_fields) => {
+    return new Promise((resolve, reject) => {
+        Papa.parse(file, {
+            header: true,
+            skipEmptyLines: true,
+            complete: (results) => {
+                if (results.errors.length > 0) {
+                    return reject(results.errors);
+                }
+                if (
+                    JSON.stringify(results.meta.fields) != expected_fields
+                ) {
+                    return reject(
+                        `Invalid fields in csv file! Expected ${expected_fields} but got ${JSON.stringify(
+                            results.meta.fields
+                        )}`
+                    );
+                }
+
+                // Parse dates
+                let data = results.data.map((elem) => {
+                    let parsed_date = Date.parse(elem.date);
+                    if (isNaN(parsed_date)) {
+                        return reject(`Invalid date ${elem.date} found`);
+                    }
+                    elem.date = parsed_date;
+                    return elem;
+                });
+
+                // Sort by date
+                data.sort((a, b) => a.date - b.date);
+
+                return resolve(data);
+            },
+            error: (error) => {
+                return reject(error);
+            },
+        });
+    });
+};
+
+onmessage = async (msg) => {
+    // Load csv file
+    if (msg.data.file) {
+        try {
+            console.log("Reading csv file in worker...");
+            let data = await parse_csv(msg.data.file, msg.data.expected_fields);
+            postMessage({ result: data });
+        } catch (e) {
+            postMessage({ error: e });
+        }
+    }
+}


### PR DESCRIPTION
- Load in CSV in a web worker to prevent UI lockups.
- Precompute some lookup tables to make UI more responsive for large files
- Generate a single path for all linegraph elements (instead of creating an SVG circle and thus a DOM element per datapoint) to improve drawing performance for large datasets